### PR TITLE
IO Error fixed on Windows.

### DIFF
--- a/plugin/broot.vim
+++ b/plugin/broot.vim
@@ -1,6 +1,11 @@
 let s:broot_command = 'broot'
 let s:out_file_path = tempname()
-let s:broot_default_config_path = fnamemodify(expand('$XDG_CONFIG_HOME/broot/conf.hjson'), ':p')
+if has("win64") || has("win32") || has("win16")
+    " Path if broot was installed by winget on Windows
+    let s:broot_default_config_path = fnamemodify(expand('$HOME/AppData/Roaming/dystroy/broot/config/conf.hjson'), ':p')
+else
+    let s:broot_default_config_path = fnamemodify(expand('$XDG_CONFIG_HOME/broot/conf.hjson'), ':p')
+endif
 let s:broot_nvim_config_path = fnamemodify(s:broot_default_config_path, ':h') . '/nvim.hjson'
 let s:broot_config_path = s:broot_default_config_path . ';' . s:broot_nvim_config_path
 


### PR DESCRIPTION
On Windows (Win 10) `:Broot` command returns an error that disappears quickly. I've installed broot with winget.
Error message: IO Error : "The system cannot find the path specified. (os error 3)"

With this small fix it's working for me.